### PR TITLE
chore: standardize Openfort/Shield env var names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Shield credentials - get from https://dashboard.openfort.io
-SHIELD_API_KEY=
-SHIELD_ENCRYPTION_SHARE=
+SHIELD_PUBLISHABLE_KEY=
+SHIELD_ENCRYPTION_KEY=
 SHIELD_SECRET_KEY=
 
 # Android Digital Asset Links (served via /.well-known/assetlinks.json)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,9 +75,9 @@ Create a `.env` file based on `.env.example`:
 
 ```
 # Openfort Shield (required for wallet encryption)
-SHIELD_API_KEY=
+SHIELD_PUBLISHABLE_KEY=
 SHIELD_SECRET_KEY=
-SHIELD_ENCRYPTION_SHARE=
+SHIELD_ENCRYPTION_KEY=
 
 # Android passkey verification
 ANDROID_PACKAGE_NAME=com.openfort.exposample

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Edit `.env` with your values:
 
 ```sh
 # Get from https://dashboard.openfort.io
-SHIELD_API_KEY=your-shield-api-key
-SHIELD_ENCRYPTION_SHARE=your-encryption-share
+SHIELD_PUBLISHABLE_KEY=your-shield-api-key
+SHIELD_ENCRYPTION_KEY=your-encryption-share
 SHIELD_SECRET_KEY=your-shield-secret-key
 
 # Android passkeys (see Passkeys section below)

--- a/app/api/protected-create-encryption-session+api.ts
+++ b/app/api/protected-create-encryption-session+api.ts
@@ -1,7 +1,7 @@
 export async function POST() {
-	const shieldApiKey = process.env.SHIELD_API_KEY;
+	const shieldApiKey = process.env.SHIELD_PUBLISHABLE_KEY;
 	const shieldSecretKey = process.env.SHIELD_SECRET_KEY;
-	const shieldEncryptionShare = process.env.SHIELD_ENCRYPTION_SHARE;
+	const shieldEncryptionShare = process.env.SHIELD_ENCRYPTION_KEY;
 
 	if (!shieldApiKey || !shieldSecretKey || !shieldEncryptionShare) {
 		console.error("Missing required Shield environment variables");


### PR DESCRIPTION
## Summary

Standardizes Shield environment variable names to the canonical scheme. Only the base token is changed; existing prefixes and values are untouched.

| Old | New |
| --- | --- |
| `SHIELD_API_KEY` | `SHIELD_PUBLISHABLE_KEY` |
| `SHIELD_ENCRYPTION_SHARE` | `SHIELD_ENCRYPTION_KEY` |

`SHIELD_SECRET_KEY` is already canonical and was left unchanged. Unrelated vars (`ANDROID_PACKAGE_NAME`, `APPLE_BUNDLE_ID`) were not touched.

## Files changed
- `.env.example`
- `README.md`
- `CLAUDE.md`
- `app/api/protected-create-encryption-session+api.ts`

## Manual update required
After merging, update the renamed variables anywhere they are configured outside this repo (local `.env` files and any CI/hosting secrets) so the new names are used. This repo is not deployed under an openfort.io subdomain, so no Vercel changes are expected. No GitHub Actions workflows reference these variables.